### PR TITLE
Optimize honor graph analytics

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,6 +21,7 @@
             <a href="#/home" data-view="home" class="nav-link active">סקירה כללית</a>
             <a href="#/city" data-view="city" class="nav-link">מבט עיר</a>
             <a href="#/street" data-view="street" class="nav-link">מבט רחוב</a>
+            <a href="#/dedications" data-view="dedications" class="nav-link">שרשראות ערים</a>
             <a href="#/graph" data-view="graph" class="nav-link">רשת הדמיון</a>
           </nav>
         </aside>
@@ -133,6 +134,36 @@
               </div>
               <div id="graph-view-canvas" class="viz-canvas network full"></div>
             </section>
+          </section>
+
+          <section id="dedications-view" class="view" data-view="dedications" hidden>
+            <div class="card chain-intro">
+              <h2>רשת הערים המונצחות ברחובות</h2>
+              <p>
+                בכל פעם שעיר מעניקה שם של עיר אחרת לרחוב, נוצר חיבור מיוחד ביניהן. הסעיף הבא מציג גרף מכוון שבו קשת מעיר מקור לעיר היעד מציינת שיש ברחובותיה שם של העיר השנייה. עובי הקשת משקף כמה שמות רחובות שונים נמצאו.
+              </p>
+            </div>
+
+            <section class="card chain-summary" id="city-chain-summary"></section>
+
+            <section class="viz-card card">
+              <div class="viz-header">
+                <h3>גרף ההנצחות בין ערים</h3>
+                <p>הקשתות המוארות מדגישות את המסלול הארוך ביותר ואת המעגל הארוך ביותר שנמצאו.</p>
+              </div>
+              <div id="city-chain-graph" class="viz-canvas network chain"></div>
+            </section>
+
+            <div class="chain-stats-grid">
+              <section class="card chain-path">
+                <h3>המסלול הארוך ביותר</h3>
+                <div id="city-chain-path" class="chain-sequence"></div>
+              </section>
+              <section class="card chain-cycle">
+                <h3>המעגל הארוך ביותר</h3>
+                <div id="city-chain-cycle" class="chain-sequence"></div>
+              </section>
+            </div>
           </section>
         </main>
       </div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -28,6 +28,14 @@ const state = {
   similarityLookup: new Map(),
   streetIndex: new Map(),
   rarityWeights: {},
+  cityHonors: {
+    graph: null,
+    nodesById: new Map(),
+    pathEdgeKeys: new Set(),
+    cycleEdgeKeys: new Set(),
+    pathNodeIds: new Set(),
+    cycleNodeIds: new Set()
+  },
   fuse: null,
   cityFuse: null,
   cityCoords: null,
@@ -44,7 +52,8 @@ const state = {
   rendered: {
     networkPreview: false,
     heatmap: false,
-    graphFull: false
+    graphFull: false,
+    cityHonors: false
   }
 };
 
@@ -61,6 +70,12 @@ const elements = {
     canvas: document.getElementById('graph-view-canvas'),
     layoutSelect: document.getElementById('graph-layout-select'),
     metricSelect: document.getElementById('graph-metric-select')
+  },
+  dedications: {
+    summary: document.getElementById('city-chain-summary'),
+    graph: document.getElementById('city-chain-graph'),
+    path: document.getElementById('city-chain-path'),
+    cycle: document.getElementById('city-chain-cycle')
   },
   city: {
     primarySelect: document.getElementById('city-select-primary'),
@@ -83,6 +98,10 @@ const elements = {
 
 let streetMapInstance = null;
 let resizeTimer = null;
+
+function makeEdgeKey(source, target) {
+  return `${source}__${target}`;
+}
 
 function toggleLoading(show, message = 'טוען נתונים...') {
   let overlay = document.getElementById('app-loading-overlay');
@@ -539,6 +558,8 @@ function onRouteChange() {
         window.location.hash = expectedHash;
       }
     }
+  } else if (view === 'dedications') {
+    renderCityDedicationView(true);
   } else if (view === 'graph') {
     state.rendered.graphFull = false;
     renderGraphView(true);
@@ -551,10 +572,14 @@ async function loadData() {
   toggleLoading(true, 'טוען נתוני בסיס...');
   try {
     const base = `${import.meta.env.BASE_URL}data/processed`;
-    const fetchJson = async (name) => {
+    const fetchJson = async (name, { optional = false } = {}) => {
       console.info(`[data] fetching ${name}`);
       const response = await fetch(`${base}/${name}`, { cache: 'no-store' });
       if (!response.ok) {
+        if (optional && response.status === 404) {
+          console.warn('[data] optional dataset missing', name);
+          return null;
+        }
         console.error('[data] fetch failed', name, response.status, response.statusText);
         throw new Error(`לא ניתן לטעון את הקובץ ${name} (סטטוס ${response.status})`);
       }
@@ -568,11 +593,12 @@ async function loadData() {
       return payload;
     };
 
-    const [cities, similarityTop, streetIndex, rarity] = await Promise.all([
+    const [cities, similarityTop, streetIndex, rarity, honorGraph] = await Promise.all([
       fetchJson('cities.json'),
       fetchJson('similarity_top.json'),
       fetchJson('street_index.json'),
-      fetchJson('rarity_weights.json')
+      fetchJson('rarity_weights.json'),
+      fetchJson('city_name_graph.json', { optional: true })
     ]);
 
     console.info('[data] datasets loaded', {
@@ -636,6 +662,7 @@ async function loadData() {
       }
     });
     state.rarityWeights = rarity || {};
+    state.cityHonors = prepareCityHonorGraph(honorGraph);
     state.cityFuse = state.cities.length
       ? new Fuse(state.cities, {
           keys: ['name'],
@@ -647,6 +674,7 @@ async function loadData() {
     state.rendered.networkPreview = false;
     state.rendered.heatmap = false;
     state.rendered.graphFull = false;
+    state.rendered.cityHonors = false;
 
     const streetItems = Array.from(state.streetIndex.entries()).map(([key, value]) => ({
       key,
@@ -696,6 +724,72 @@ async function loadData() {
     toggleLoading(false);
     console.timeEnd('[data] total');
   }
+}
+
+function prepareCityHonorGraph(raw) {
+  const base = {
+    graph: null,
+    nodesById: new Map(),
+    pathEdgeKeys: new Set(),
+    cycleEdgeKeys: new Set(),
+    pathNodeIds: new Set(),
+    cycleNodeIds: new Set()
+  };
+
+  if (!raw || typeof raw !== 'object') {
+    return base;
+  }
+
+  const graph = {
+    nodes: Array.isArray(raw.nodes) ? raw.nodes.map(node => ({
+      ...node,
+      id: String(node.id)
+    })) : [],
+    links: Array.isArray(raw.links) ? raw.links.map(link => ({
+      ...link,
+      source: String(link.source),
+      target: String(link.target)
+    })) : [],
+    stats: raw.stats || {}
+  };
+
+  const nodesById = new Map(graph.nodes.map(node => [node.id, node]));
+
+  const pathEdgeKeys = new Set();
+  const cycleEdgeKeys = new Set();
+  const pathNodeIds = new Set();
+  const cycleNodeIds = new Set();
+
+  const pathEntry = graph.stats?.longestPath;
+  if (pathEntry && Array.isArray(pathEntry.cities)) {
+    pathEntry.cities.forEach(cityId => pathNodeIds.add(String(cityId)));
+  }
+  if (pathEntry && Array.isArray(pathEntry.edges)) {
+    pathEntry.edges.forEach(edge => {
+      if (!edge || edge.source === undefined || edge.target === undefined) return;
+      pathEdgeKeys.add(makeEdgeKey(String(edge.source), String(edge.target)));
+    });
+  }
+
+  const cycleEntry = graph.stats?.longestCycle;
+  if (cycleEntry && Array.isArray(cycleEntry.cities)) {
+    cycleEntry.cities.forEach(cityId => cycleNodeIds.add(String(cityId)));
+  }
+  if (cycleEntry && Array.isArray(cycleEntry.edges)) {
+    cycleEntry.edges.forEach(edge => {
+      if (!edge || edge.source === undefined || edge.target === undefined) return;
+      cycleEdgeKeys.add(makeEdgeKey(String(edge.source), String(edge.target)));
+    });
+  }
+
+  return {
+    graph,
+    nodesById,
+    pathEdgeKeys,
+    cycleEdgeKeys,
+    pathNodeIds,
+    cycleNodeIds
+  };
 }
 
 function renderHome(force = false) {
@@ -1204,6 +1298,303 @@ function renderGraphView(force = false) {
     metric: state.graphSettings.metric
   });
   state.rendered.graphFull = true;
+}
+
+
+function renderCityDedicationSummary(graphData) {
+  const container = elements.dedications.summary;
+  if (!container) return;
+  if (!graphData || !graphData.stats || !Array.isArray(graphData.nodes) || !graphData.nodes.length) {
+    container.innerHTML = '<p class="empty-state">לא נמצאו קשרי הנצחה בין ערים.</p>';
+    return;
+  }
+
+  const { stats } = graphData;
+  const cityCount = stats.cityCount || 0;
+  const edgeCount = stats.edgeCount || 0;
+  const streetRefs = stats.streetReferenceCount || 0;
+  const average = cityCount ? (streetRefs / cityCount).toFixed(1) : '0.0';
+
+  const blocks = [
+    {
+      label: 'ערים ברשת',
+      value: cityCount,
+      note: 'ערים שמנציחות או מונצחות'
+    },
+    {
+      label: 'קשתות הנצחה',
+      value: edgeCount,
+      note: 'עיר → עיר אחרת'
+    },
+    {
+      label: 'סה"כ אזכורי רחובות',
+      value: streetRefs,
+      note: `ממוצע ${average} שמות רחוב לעיר`
+    }
+  ];
+
+  container.innerHTML = blocks
+    .map(block => `
+      <div class="summary-block">
+        <span class="summary-label">${block.label}</span>
+        <span class="summary-value">${block.value}</span>
+        <span class="summary-note">${block.note}</span>
+      </div>
+    `)
+    .join('');
+}
+
+function renderCityChainSequence(container, entry, fallbackMessage) {
+  if (!container) return;
+  container.innerHTML = '';
+  container.classList.remove('empty');
+
+  if (!entry || !Array.isArray(entry.cities) || entry.cities.length <= 1) {
+    container.textContent = fallbackMessage;
+    container.classList.add('empty');
+    return;
+  }
+
+  const row = document.createElement('div');
+  row.className = 'chain-row';
+
+  const edges = Array.isArray(entry.edges) ? entry.edges : [];
+
+  entry.cities.forEach((cityId, index) => {
+    const name = entry.cityNames && entry.cityNames[index]
+      ? entry.cityNames[index]
+      : state.cityMap.get(String(cityId))?.name || state.cityHonors.nodesById.get(String(cityId))?.name || String(cityId);
+
+    const nodeLabel = document.createElement('span');
+    nodeLabel.className = 'chain-node-label';
+    nodeLabel.textContent = name;
+    row.appendChild(nodeLabel);
+
+    if (index >= entry.cities.length - 1) {
+      return;
+    }
+
+    const arrow = document.createElement('span');
+    arrow.className = 'chain-arrow';
+    arrow.textContent = '⇢';
+    row.appendChild(arrow);
+
+    const edgeInfo = edges[index];
+    if (edgeInfo) {
+      const count = edgeInfo.streetCount || (edgeInfo.streetNames ? edgeInfo.streetNames.length : 0) || 1;
+      const examples = Array.isArray(edgeInfo.streetNames)
+        ? edgeInfo.streetNames.filter(Boolean).slice(0, 3).join(' · ')
+        : '';
+      const note = document.createElement('span');
+      note.className = 'chain-edge-note';
+      const baseLabel = count === 1 ? 'רחוב אחד' : `${count} רחובות`;
+      note.textContent = examples ? `${baseLabel} · ${examples}` : baseLabel;
+      row.appendChild(note);
+    }
+  });
+
+  container.appendChild(row);
+}
+
+function renderCityHonorGraph(force = false) {
+  const container = elements.dedications.graph;
+  if (!container) return;
+  if (!force && state.rendered.cityHonors) return;
+
+  container.innerHTML = '';
+
+  const graphData = state.cityHonors.graph;
+  if (!graphData || !Array.isArray(graphData.nodes) || !graphData.nodes.length) {
+    container.innerHTML = '<p class="empty-state">אין נתונים להצגה. הריצו את תהליך העיבוד כדי ליצור את הקובץ city_name_graph.json.</p>';
+    return;
+  }
+
+  const bounds = container.getBoundingClientRect();
+  const width = Math.max(bounds.width || container.clientWidth || 0, 720);
+  const height = Math.max(bounds.height || 0, 520);
+
+  const svg = d3
+    .select(container)
+    .append('svg')
+    .attr('viewBox', `0 0 ${width} ${height}`)
+    .attr('preserveAspectRatio', 'xMidYMid meet');
+
+  const defs = svg.append('defs');
+  const markerConfigs = [
+    { id: 'chain-arrow', color: 'rgba(148,163,255,0.65)' },
+    { id: 'chain-arrow-path', color: '#22d3ee' },
+    { id: 'chain-arrow-cycle', color: '#facc15' }
+  ];
+
+  markerConfigs.forEach(config => {
+    defs
+      .append('marker')
+      .attr('id', config.id)
+      .attr('orient', 'auto')
+      .attr('markerWidth', 10)
+      .attr('markerHeight', 10)
+      .attr('refX', 12)
+      .attr('refY', 3)
+      .attr('viewBox', '0 0 12 6')
+      .append('path')
+      .attr('d', 'M0,0 L12,3 L0,6 Z')
+      .attr('fill', config.color);
+  });
+
+  const nodes = graphData.nodes.map(node => ({ ...node }));
+  const links = graphData.links.map(link => ({
+    ...link,
+    source: link.source,
+    target: link.target,
+    _source: link.source,
+    _target: link.target
+  }));
+
+  const pathEdgeKeys = state.cityHonors.pathEdgeKeys || new Set();
+  const cycleEdgeKeys = state.cityHonors.cycleEdgeKeys || new Set();
+  const pathNodeIds = state.cityHonors.pathNodeIds || new Set();
+  const cycleNodeIds = state.cityHonors.cycleNodeIds || new Set();
+
+  const linkGroup = svg.append('g').attr('class', 'chain-links');
+  const nodeGroup = svg.append('g').attr('class', 'chain-nodes');
+
+  const linkSelection = linkGroup
+    .selectAll('line')
+    .data(links)
+    .enter()
+    .append('line')
+    .attr('class', d => {
+      const key = makeEdgeKey(d._source, d._target);
+      const classes = ['chain-link'];
+      if (pathEdgeKeys.has(key)) classes.push('is-path');
+      if (cycleEdgeKeys.has(key)) classes.push('is-cycle');
+      return classes.join(' ');
+    })
+    .attr('stroke-width', d => 1.2 + Math.min(d.streetCount || (d.streets ? d.streets.length : 1), 6) * 0.8)
+    .attr('marker-end', d => {
+      const key = makeEdgeKey(d._source, d._target);
+      if (pathEdgeKeys.has(key)) return 'url(#chain-arrow-path)';
+      if (cycleEdgeKeys.has(key)) return 'url(#chain-arrow-cycle)';
+      return 'url(#chain-arrow)';
+    });
+
+  linkSelection.append('title').text(d => {
+    const sourceName = state.cityMap.get(d._source)?.name || state.cityHonors.nodesById.get(d._source)?.name || d._source;
+    const targetName = state.cityMap.get(d._target)?.name || state.cityHonors.nodesById.get(d._target)?.name || d._target;
+    const count = d.streetCount || (d.streets ? d.streets.length : 0);
+    const names = Array.isArray(d.streets) ? d.streets.map(street => street.display).filter(Boolean).slice(0, 4).join(', ') : '';
+    const base = count === 1 ? 'רחוב אחד' : `${count} רחובות`;
+    return names ? `${sourceName} → ${targetName}\n${base}: ${names}` : `${sourceName} → ${targetName}\n${base}`;
+  });
+
+  const nodeSelection = nodeGroup
+    .selectAll('g')
+    .data(nodes)
+    .enter()
+    .append('g')
+    .attr('class', d => {
+      const classes = ['chain-node'];
+      if (pathNodeIds.has(d.id)) classes.push('is-path');
+      if (cycleNodeIds.has(d.id)) classes.push('is-cycle');
+      return classes.join(' ');
+    })
+    .call(
+      d3
+        .drag()
+        .on('start', event => {
+          if (!event.active) simulation.alphaTarget(0.3).restart();
+          event.subject.fx = event.subject.x;
+          event.subject.fy = event.subject.y;
+        })
+        .on('drag', event => {
+          event.subject.fx = event.x;
+          event.subject.fy = event.y;
+        })
+        .on('end', event => {
+          if (!event.active) simulation.alphaTarget(0);
+          event.subject.fx = null;
+          event.subject.fy = null;
+        })
+    );
+
+  nodeSelection
+    .append('circle')
+    .attr('r', d => 18 + Math.sqrt((d.honorStreetOut || 0) + (d.honorStreetIn || 0)) * 3);
+
+  nodeSelection
+    .append('text')
+    .attr('text-anchor', 'middle')
+    .attr('dominant-baseline', 'middle')
+    .text(d => d.name || d.displayName || d.id);
+
+  nodeSelection.append('title').text(d => {
+    const honorsOut = d.honorsOut || 0;
+    const honorsIn = d.honorsIn || 0;
+    const streetOut = d.honorStreetOut || 0;
+    const streetIn = d.honorStreetIn || 0;
+    return `${d.name || d.id}\nמנציחה ${honorsOut} ערים (${streetOut} שמות רחובות)\nמונצחת ב-${honorsIn} ערים (${streetIn} שמות)`;
+  });
+
+  const simulation = d3
+    .forceSimulation(nodes)
+    .force(
+      'link',
+      d3
+        .forceLink(links)
+        .id(d => d.id)
+        .distance(d => 150 - Math.min(d.streetCount || (d.streets ? d.streets.length : 1), 5) * 8)
+        .strength(0.4)
+    )
+    .force('charge', d3.forceManyBody().strength(-420))
+    .force('center', d3.forceCenter(width / 2, height / 2))
+    .force('collision', d3.forceCollide().radius(d => 26 + Math.sqrt((d.honorStreetOut || 0) + (d.honorStreetIn || 0)) * 3.5));
+
+  simulation.on('tick', () => {
+    nodes.forEach(node => clampNodeToBounds(node, width, height, 40));
+    linkSelection
+      .attr('x1', d => d.source.x)
+      .attr('y1', d => d.source.y)
+      .attr('x2', d => d.target.x)
+      .attr('y2', d => d.target.y);
+    nodeSelection.attr('transform', d => `translate(${d.x}, ${d.y})`);
+  });
+
+  simulation.alpha(1).restart();
+}
+
+function renderCityDedicationView(force = false) {
+  const graphData = state.cityHonors.graph;
+  if (!graphData || !Array.isArray(graphData.nodes) || !graphData.nodes.length) {
+    if (elements.dedications.summary) {
+      elements.dedications.summary.innerHTML = '<p class="empty-state">לא נמצאו קשרים בין ערים. הריצו את תהליך העיבוד כדי ליצור נתונים.</p>';
+    }
+    if (elements.dedications.graph) {
+      elements.dedications.graph.innerHTML = '<p class="empty-state">הגרף יופיע כאן לאחר יצירת הקובץ city_name_graph.json.</p>';
+    }
+    if (elements.dedications.path) {
+      elements.dedications.path.textContent = 'לא נמצא מסלול הנצחה מרובה ערים.';
+      elements.dedications.path.classList.add('empty');
+    }
+    if (elements.dedications.cycle) {
+      elements.dedications.cycle.textContent = 'לא נמצא מעגל הנצחה בין ערים.';
+      elements.dedications.cycle.classList.add('empty');
+    }
+    state.rendered.cityHonors = true;
+    return;
+  }
+
+  if (!force && state.rendered.cityHonors) return;
+
+  renderCityDedicationSummary(graphData);
+  renderCityHonorGraph(true);
+
+  const pathEntry = graphData.stats?.longestPath || null;
+  const cycleEntry = graphData.stats?.longestCycle || null;
+
+  renderCityChainSequence(elements.dedications.path, pathEntry, 'לא נמצא מסלול הנצחה מרובה ערים.');
+  renderCityChainSequence(elements.dedications.cycle, cycleEntry, 'לא נמצא מעגל שבו כל עיר מנציחה את הבאה וחוזרת לעצמה.');
+
+  state.rendered.cityHonors = true;
 }
 
 
@@ -2046,6 +2437,9 @@ function handleResize() {
   const { view } = parseHash();
   if (view === 'home') {
     renderHome(true);
+  } else if (view === 'dedications') {
+    state.rendered.cityHonors = false;
+    renderCityDedicationView(true);
   } else if (view === 'graph') {
     state.rendered.graphFull = false;
     renderGraphView(true);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -158,6 +158,10 @@ a:hover {
   min-height: clamp(540px, 68vh, 780px);
 }
 
+.viz-canvas.network.chain {
+  min-height: clamp(520px, 70vh, 780px);
+}
+
 #graph-view-canvas {
   width: 100%;
   height: 100%;
@@ -227,6 +231,37 @@ a:hover {
 .top-cities-list span.count {
   color: var(--accent);
   font-weight: 600;
+}
+
+.chain-summary {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.chain-summary .summary-block {
+  background: rgba(148, 163, 255, 0.08);
+  border-radius: 16px;
+  padding: 1rem 1.2rem;
+  border: 1px solid rgba(148, 163, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.chain-summary .summary-label {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.chain-summary .summary-value {
+  font-size: 1.7rem;
+  font-weight: 700;
+}
+
+.chain-summary .summary-note {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 255, 0.8);
 }
 
 .form-card {
@@ -589,6 +624,124 @@ button:disabled {
 .overlap-actions button {
   padding: 0.45rem 1rem;
   font-size: 0.9rem;
+}
+
+.chain-stats-grid {
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.6rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.chain-sequence {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.chain-sequence.empty {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.chain-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  background: rgba(15, 23, 42, 0.35);
+  border-radius: 14px;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid rgba(148, 163, 255, 0.12);
+}
+
+.chain-node-label {
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.chain-arrow {
+  font-size: 1.2rem;
+  color: var(--accent);
+}
+
+.chain-edge-note {
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.82);
+  background: rgba(14, 165, 233, 0.14);
+  border-radius: 12px;
+  padding: 0.25rem 0.6rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.chain-edge-note strong {
+  font-weight: 600;
+}
+
+#city-chain-graph svg {
+  width: 100%;
+  height: 100%;
+}
+
+.chain-link {
+  stroke: rgba(148, 163, 255, 0.55);
+  fill: none;
+  stroke-width: 1.6px;
+  transition: stroke 0.2s ease;
+}
+
+.chain-link.is-path {
+  stroke: #22d3ee;
+}
+
+.chain-link.is-cycle {
+  stroke: #facc15;
+}
+
+.chain-node {
+  cursor: grab;
+}
+
+.chain-node circle {
+  fill: rgba(30, 64, 175, 0.68);
+  stroke: rgba(148, 163, 255, 0.7);
+  stroke-width: 1.6px;
+}
+
+.chain-node.is-path circle {
+  stroke: #22d3ee;
+  stroke-width: 2.4px;
+}
+
+.chain-node.is-cycle circle {
+  stroke: #facc15;
+  stroke-width: 2.4px;
+}
+
+.chain-node text {
+  font-size: 0.85rem;
+  font-weight: 600;
+  fill: var(--text);
+  pointer-events: none;
+}
+
+.chain-intro p {
+  color: var(--muted);
+}
+
+.chain-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: rgba(15, 23, 42, 0.94);
+  border: 1px solid rgba(34, 211, 238, 0.3);
+  border-radius: 12px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  z-index: 10;
 }
 
 @media (max-width: 1024px) {

--- a/src/aggregation/build_data.py
+++ b/src/aggregation/build_data.py
@@ -12,11 +12,19 @@ import logging
 import math
 import os
 import shutil
+import sys
 import time
 from collections import Counter, defaultdict
 from pathlib import Path
 
 import networkx as nx
+
+# Allow running the script directly without requiring PYTHONPATH tweaks
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from src.normalization.norm_data import normalize_name
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -32,6 +40,7 @@ class StreetProcessingPipeline:
         self.rarity_weights = {}
         self.city_names = {}
         self.city_communities = {}
+        self.city_name_graph = {}
 
     def load_data(self, csv_path):
         """Load street data from CSV file."""
@@ -229,6 +238,245 @@ class StreetProcessingPipeline:
 
         return self
 
+    def build_city_name_honor_graph(self):
+        """Build a directed graph of cities that name streets after other cities."""
+        logger.info("Building city honor graph based on street names")
+        start_time = time.time()
+
+        city_key_to_codes = defaultdict(set)
+        city_display_by_code = {}
+
+        def _city_name_lookup(raw_code):
+            try:
+                return self.city_names.get(int(raw_code), '')
+            except (TypeError, ValueError):
+                return self.city_names.get(raw_code, '')
+
+        for code, name in self.city_names.items():
+            normalized = normalize_name(name, drop_he=False)
+            city_display_by_code[code] = normalized["display"] or name
+            key = normalized["key"]
+            if key:
+                city_key_to_codes[key].add(code)
+
+            dropped = normalize_name(name, drop_he=True)
+            dropped_key = dropped["key"]
+            if dropped_key and dropped_key != key:
+                city_key_to_codes[dropped_key].add(code)
+
+        edges = {}
+        active_cities = set()
+
+        for source_code, streets in self.city_street_meta.items():
+            for norm_key, meta in streets.items():
+                target_codes = city_key_to_codes.get(norm_key)
+                if not target_codes:
+                    continue
+                for target_code in target_codes:
+                    if target_code == source_code:
+                        continue
+                    edge_key = (str(source_code), str(target_code))
+                    street_record = {
+                        'normKey': norm_key,
+                        'display': meta.get('display') or self.norm_keys.get(norm_key, norm_key),
+                        'normDisplay': meta.get('norm_display') or self.cities_data[source_code].get(norm_key, ''),
+                        'streetCode': meta.get('street_code', '')
+                    }
+                    entry = edges.setdefault(edge_key, {
+                        'source': edge_key[0],
+                        'target': edge_key[1],
+                        'streets': []
+                    })
+                    entry['streets'].append(street_record)
+                    active_cities.update(edge_key)
+
+        if not edges:
+            self.city_name_graph = {
+                'nodes': [],
+                'links': [],
+                'stats': {
+                    'cityCount': 0,
+                    'edgeCount': 0,
+                    'streetReferenceCount': 0,
+                    'longestPath': None,
+                    'longestCycle': None
+                }
+            }
+            logger.warning("No inter-city honor edges detected")
+            return self
+
+        def _collect_edge_details(sequence):
+            details = []
+            for src, dst in zip(sequence, sequence[1:]):
+                edge_info = edges.get((src, dst))
+                if not edge_info:
+                    continue
+                details.append({
+                    'source': src,
+                    'target': dst,
+                    'streetCount': len(edge_info['streets']),
+                    'streetNames': [street['display'] for street in edge_info['streets']]
+                })
+            return details
+
+        analysis_adjacency = defaultdict(list)
+        for (src, dst), data in edges.items():
+            weight = len(data['streets'])
+            analysis_adjacency[src].append((dst, weight))
+
+        trimmed_adjacency = {}
+        analysis_limit = 4
+        for source, neighbors in analysis_adjacency.items():
+            if not neighbors:
+                continue
+            sorted_neighbors = sorted(neighbors, key=lambda item: item[1], reverse=True)[:analysis_limit]
+            trimmed_adjacency[source] = sorted_neighbors
+
+        for node in active_cities:
+            trimmed_adjacency.setdefault(node, [])
+
+        longest_path = []
+        max_states = 250000
+        state_counter = 0
+
+        for start in active_cities:
+            if state_counter >= max_states:
+                break
+            stack = [(start, [start], {start})]
+            while stack:
+                node, path, visited = stack.pop()
+                state_counter += 1
+                if len(path) > len(longest_path):
+                    longest_path = list(path)
+                if state_counter >= max_states:
+                    logger.warning(
+                        "Longest path search hit state cap (%d); partial result length=%d",
+                        max_states,
+                        len(longest_path)
+                    )
+                    stack = []
+                    break
+                for neighbor, _ in trimmed_adjacency.get(node, []):
+                    if neighbor in visited:
+                        continue
+                    stack.append((neighbor, path + [neighbor], visited | {neighbor}))
+
+        digraph = nx.DiGraph()
+        digraph.add_nodes_from(active_cities)
+        for (src, dst), data in edges.items():
+            digraph.add_edge(src, dst, weight=len(data['streets']))
+
+        cycle_entry = None
+        path_entry = None
+
+        if len(longest_path) > 1:
+            path_details = _collect_edge_details(longest_path)
+            path_entry = {
+                'length': len(longest_path),
+                'cities': list(longest_path),
+                'cityNames': [_city_name_lookup(code) for code in longest_path],
+                'edges': path_details
+            }
+
+        analysis_graph = nx.DiGraph()
+        analysis_graph.add_nodes_from(active_cities)
+        for source, neighbors in trimmed_adjacency.items():
+            for target, _ in neighbors:
+                analysis_graph.add_edge(source, target)
+
+        try:
+            longest_cycle_nodes = []
+            cycle_cap = 5000
+            for index, cycle_nodes in enumerate(nx.simple_cycles(analysis_graph), start=1):
+                if len(cycle_nodes) > len(longest_cycle_nodes):
+                    longest_cycle_nodes = cycle_nodes
+                if index >= cycle_cap:
+                    logger.warning(
+                        "Cycle enumeration hit cap (%d); best cycle length=%d",
+                        cycle_cap,
+                        len(longest_cycle_nodes)
+                    )
+                    break
+        except nx.NetworkXNoCycle:
+            longest_cycle_nodes = []
+
+        if longest_cycle_nodes:
+            cycle_sequence = list(longest_cycle_nodes) + [longest_cycle_nodes[0]]
+            cycle_details = _collect_edge_details(cycle_sequence)
+            cycle_entry = {
+                'length': len(cycle_sequence) - 1,
+                'cities': list(cycle_sequence),
+                'cityNames': [_city_name_lookup(code) for code in cycle_sequence],
+                'edges': cycle_details
+            }
+
+        out_counts = Counter()
+        in_counts = Counter()
+        out_streets = Counter()
+        in_streets = Counter()
+
+        for (src, dst), data in edges.items():
+            out_counts[src] += 1
+            in_counts[dst] += 1
+            street_total = len(data['streets'])
+            out_streets[src] += street_total
+            in_streets[dst] += street_total
+
+        nodes_output = []
+        total_street_refs = 0
+        for code in sorted(active_cities, key=lambda cid: _city_name_lookup(cid)):
+            try:
+                numeric_code = int(code)
+            except (TypeError, ValueError):
+                numeric_code = code
+            street_count = len(self.cities_data.get(numeric_code, {}))
+            honor_out = out_counts.get(code, 0)
+            honor_in = in_counts.get(code, 0)
+            honor_out_streets = out_streets.get(code, 0)
+            honor_in_streets = in_streets.get(code, 0)
+            total_street_refs += honor_out_streets
+            nodes_output.append({
+                'id': code,
+                'name': _city_name_lookup(code),
+                'displayName': city_display_by_code.get(numeric_code, _city_name_lookup(code)),
+                'streetCount': street_count,
+                'honorsOut': honor_out,
+                'honorsIn': honor_in,
+                'honorStreetOut': honor_out_streets,
+                'honorStreetIn': honor_in_streets
+            })
+
+        links_output = []
+        for (src, dst), data in sorted(edges.items(), key=lambda item: (item[0][0], item[0][1])):
+            links_output.append({
+                'source': src,
+                'target': dst,
+                'streetCount': len(data['streets']),
+                'streets': data['streets']
+            })
+
+        self.city_name_graph = {
+            'nodes': nodes_output,
+            'links': links_output,
+            'stats': {
+                'cityCount': len(active_cities),
+                'edgeCount': len(links_output),
+                'streetReferenceCount': total_street_refs,
+                'longestPath': path_entry,
+                'longestCycle': cycle_entry
+            }
+        }
+
+        elapsed = time.time() - start_time
+        logger.info(
+            "City honor graph ready: %d nodes, %d edges (%.2fs)",
+            len(nodes_output),
+            len(links_output),
+            elapsed
+        )
+
+        return self
+
     def calculate_city_similarities(self):
         """Calculate similarities between all city pairs."""
         logger.info("Calculating city similarities")
@@ -374,6 +622,10 @@ class StreetProcessingPipeline:
         with open(os.path.join(output_dir, 'rarity_weights.json'), 'w', encoding='utf-8') as f:
             json.dump(self.rarity_weights, f, indent=2, ensure_ascii=False)
 
+        if self.city_name_graph:
+            with open(os.path.join(output_dir, 'city_name_graph.json'), 'w', encoding='utf-8') as f:
+                json.dump(self.city_name_graph, f, indent=2, ensure_ascii=False)
+
         # Export similarity top lists for light-weight analytics
         if top_similarities is not None:
             with open(os.path.join(output_dir, 'similarity_top.json'), 'w', encoding='utf-8') as f:
@@ -399,6 +651,8 @@ class StreetProcessingPipeline:
         filenames = ['cities.json', 'street_index.json', 'rarity_weights.json']
         if has_similarity_top:
             filenames.append('similarity_top.json')
+        if self.city_name_graph:
+            filenames.append('city_name_graph.json')
 
         for filename in filenames:
             source = output_path / filename
@@ -424,6 +678,9 @@ def main():
 
     # Compute rarity weights
     pipeline.compute_rarity_weights()
+
+    # Build city honor graph before similarity calculations
+    pipeline.build_city_name_honor_graph()
 
     # Calculate similarities
     similarities, base_pairs = pipeline.calculate_city_similarities()


### PR DESCRIPTION
## Summary
- allow the aggregation pipeline to be executed directly by adding the repository root to `sys.path`
- cap honor-graph exploration to the heaviest outgoing links and use iterative DFS so longest path search finishes quickly on large graphs
- enumerate cycles on the trimmed graph with a safety cap, yielding stable longest path/cycle payloads for the frontend

## Testing
- npm --prefix frontend run build
- python -m compileall src/aggregation/build_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d19fdbcae8832c9de49389cef3b2e6