### PR TITLE
Fix duplicate nodesById declaration in dedication graph

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -842,7 +842,7 @@ function prepareCityHonorGraph(raw) {
     ensureNodeDegree(link.target).in += 1;
   });
 
-  const nodesById = new Map(filteredNodes.map(node => [node.id, { ...node }]));
+  const filteredNodesById = new Map(filteredNodes.map(node => [node.id, { ...node }]));
 
   const donorsByTarget = new Map();
   filteredLinks.forEach(link => {
@@ -851,7 +851,7 @@ function prepareCityHonorGraph(raw) {
     const degree = nodeDegree.get(sourceId) || { in: 0, out: 0 };
     if (degree.out !== 1 || degree.in !== 0) return;
     if (pathNodeIds.has(sourceId) || cycleNodeIds.has(sourceId)) return;
-    const sourceNode = nodesById.get(sourceId);
+    const sourceNode = filteredNodesById.get(sourceId);
     if (!sourceNode) return;
     if (!donorsByTarget.has(targetId)) {
       donorsByTarget.set(targetId, []);


### PR DESCRIPTION
## Summary
- rename the filtered city node map to avoid redeclaring `nodesById`
- ensure donor aggregation still uses the filtered-node lookup while the returned graph map keeps its original name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2318c473c832ca6f2ad5e23a0d231