### PR TITLE
Add city uniqueness metrics and distinctive city widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@
    * Weighted Jaccard (rarity = 1/log(1+city\_count)).
    * Top-N matches per city.
    * Inverted index: `{street_name: [cities...]}`.
+   * Per-city rarity metrics: מספר הרחובות הייחודיים בעיר, חלק הרחובות הייחודיים מתוך כלל הרחובות, ממוצע וחציון משקל נדירות.
 5. **Export JSON**:
 
-   * `cities.json` (id, name, cluster\_id?).
-   * `similarity_top.json` (top matches per city).
-   * `name_index.json` (street → cities, variants).
-   * `name_meta.json` (counts, rarity).
+   * `cities.json` – מזהה, שם עיר, מספר רחובות מנורמל, שיוך לקהילה (אם זמין) ומדדי ייחודיות (כמות/חלק ייחודיים, ממוצע/חציון משקלי נדירות).
+   * `city_uniqueness.json` – דירוג ארצי של הערים לפי חלק הרחובות הייחודיים, כולל ממוצע/חציון משקלי נדירות להקשר.
+   * `similarity_top.json` – הערים הדומות ביותר לכל עיר.
+   * `street_index.json` – אינדקס רחוב ↦ רשימת ערים והצגת השם המקומית.
+   * `rarity_weights.json` – משקל נדירות לכל שם מנורמל.
 
 ### Python Environment
 
@@ -57,10 +59,12 @@ python3 -m pip install networkx
 
   * Network graph: cities as nodes, edges for Jaccard ≥ τ.
   * Heatmap: similarity between top 50 cities.
+  * "הערים עם השמות הייחודיים ביותר" – כרטיס דרוג המציג את הערים עם החלק הגבוה ביותר של שמות רחובות ייחודיים.
 * **City Page**:
 
   * Bar chart of top-10 similar cities.
   * Shared street list (top examples).
+  * Summary card includes unique-street counts, share, rarity averages and national distinctiveness rank.
 * **Street Page**:
 
   * Show display name + variants.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -55,6 +55,12 @@
               <h3>ערים בולטות לפי מספר רחובות מנורמל</h3>
               <ul id="top-cities-list" class="top-cities-list"></ul>
             </section>
+
+            <section class="card top-cities" id="distinctive-cities-panel">
+              <h3>הערים עם השמות הייחודיים ביותר</h3>
+              <p class="hint">הדירוג מחושב לפי חלק הרחובות שאינם מופיעים בערים אחרות, כשהתיקון מתבסס על משקלי נדירות.</p>
+              <ol id="distinctive-cities-list" class="top-cities-list distinctive-list"></ol>
+            </section>
           </section>
 
           <section id="city-view" class="view" data-view="city" hidden>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -28,6 +28,9 @@ const state = {
   similarityLookup: new Map(),
   streetIndex: new Map(),
   rarityWeights: {},
+  cityUniqueness: [],
+  cityUniquenessRank: new Map(),
+  cityUniquenessById: new Map(),
   cityHonors: {
     graph: null,
     nodesById: new Map(),
@@ -64,7 +67,9 @@ const elements = {
   home: {
     network: document.getElementById('network-preview'),
     heatmap: document.getElementById('similarity-heatmap'),
-    topList: document.getElementById('top-cities-list')
+    topList: document.getElementById('top-cities-list'),
+    distinctivePanel: document.getElementById('distinctive-cities-panel'),
+    distinctiveList: document.getElementById('distinctive-cities-list')
   },
   graph: {
     canvas: document.getElementById('graph-view-canvas'),
@@ -593,12 +598,13 @@ async function loadData() {
       return payload;
     };
 
-    const [cities, similarityTop, streetIndex, rarity, honorGraph] = await Promise.all([
+    const [cities, similarityTop, streetIndex, rarity, honorGraph, uniquenessRaw] = await Promise.all([
       fetchJson('cities.json'),
       fetchJson('similarity_top.json'),
       fetchJson('street_index.json'),
       fetchJson('rarity_weights.json'),
-      fetchJson('city_name_graph.json', { optional: true })
+      fetchJson('city_name_graph.json', { optional: true }),
+      fetchJson('city_uniqueness.json', { optional: true })
     ]);
 
     console.info('[data] datasets loaded', {
@@ -613,6 +619,46 @@ async function loadData() {
     state.cityMap = new Map(state.cities.map(city => [city.id, city]));
     state.cityNameLookup = new Map(state.cities.map(city => [city.name, city]));
     state.graphLayouts.clear();
+
+    const uniquenessList = Array.isArray(uniquenessRaw)
+      ? uniquenessRaw
+      : state.cities.map(city => ({
+          id: city.id,
+          name: city.name,
+          streetCount: city.streetCount,
+          uniqueStreetCount: city.uniqueStreetCount ?? 0,
+          uniqueStreetShare: city.uniqueStreetShare ?? 0,
+          meanRarityWeight: city.meanRarityWeight ?? 0,
+          medianRarityWeight: city.medianRarityWeight ?? 0
+        }));
+
+    uniquenessList.sort((a, b) => {
+      const shareDiff = (b.uniqueStreetShare || 0) - (a.uniqueStreetShare || 0);
+      if (Math.abs(shareDiff) > 1e-9) return shareDiff;
+      const countDiff = (b.uniqueStreetCount || 0) - (a.uniqueStreetCount || 0);
+      if (countDiff !== 0) return countDiff;
+      const meanDiff = (b.meanRarityWeight || 0) - (a.meanRarityWeight || 0);
+      if (Math.abs(meanDiff) > 1e-9) return meanDiff;
+      return (a.name || '').localeCompare(b.name || '');
+    });
+
+    state.cityUniqueness = uniquenessList.map((entry, index) => ({
+      ...entry,
+      rank: typeof entry.rank === 'number' ? entry.rank : index + 1
+    }));
+    state.cityUniquenessById = new Map(state.cityUniqueness.map(entry => [String(entry.id), entry]));
+    state.cityUniquenessRank = new Map(state.cityUniqueness.map(entry => [String(entry.id), entry.rank]));
+    state.cities.forEach(city => {
+      const uniqueness = state.cityUniquenessById.get(String(city.id));
+      if (!uniqueness) {
+        return;
+      }
+      city.uniqueStreetCount = uniqueness.uniqueStreetCount ?? city.uniqueStreetCount ?? 0;
+      city.uniqueStreetShare = uniqueness.uniqueStreetShare ?? city.uniqueStreetShare ?? 0;
+      city.meanRarityWeight = uniqueness.meanRarityWeight ?? city.meanRarityWeight ?? 0;
+      city.medianRarityWeight = uniqueness.medianRarityWeight ?? city.medianRarityWeight ?? 0;
+      city.uniquenessRank = uniqueness.rank ?? city.uniquenessRank;
+    });
 
     state.similarityTop = new Map(Object.entries(similarityTop || {}));
     const similarityLookup = new Map();
@@ -979,6 +1025,7 @@ function renderHome(force = false) {
   renderNetworkPreview(force);
   renderHeatmap(force);
   renderTopCitiesList();
+  renderDistinctiveCities();
   console.info('[viz] renderHome end');
   console.timeEnd('[viz] renderHome');
 }
@@ -2052,6 +2099,51 @@ function renderTopCitiesList() {
     .join('');
 }
 
+function formatPercentage(value, digits = 1) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '0%';
+  }
+  const percentage = value * 100;
+  const safeDigits = Math.max(0, Math.min(3, digits));
+  return `${percentage.toFixed(safeDigits)}%`;
+}
+
+function renderDistinctiveCities(limit = 8) {
+  const panel = elements.home.distinctivePanel;
+  const list = elements.home.distinctiveList;
+  if (!panel || !list) return;
+
+  const entries = state.cityUniqueness.slice(0, limit);
+  if (!entries.length) {
+    panel.hidden = true;
+    list.innerHTML = '';
+    return;
+  }
+
+  panel.hidden = false;
+  list.innerHTML = entries
+    .map(entry => {
+      const uniqueCount = entry.uniqueStreetCount ?? 0;
+      const share = formatPercentage(entry.uniqueStreetShare ?? 0, 1);
+      const median = typeof entry.medianRarityWeight === 'number' ? entry.medianRarityWeight : 0;
+      const mean = typeof entry.meanRarityWeight === 'number' ? entry.meanRarityWeight : 0;
+      const rank = entry.rank ?? 0;
+      return `
+        <li>
+          <div class="row-main">
+            <span class="rank">#${rank}</span>
+            <strong>${entry.name}</strong>
+          </div>
+          <div class="row-sub">
+            <span>${uniqueCount.toLocaleString()} רחובות ייחודיים (${share})</span>
+            <span>ממוצע נדירות: ${mean.toFixed(3)}, חציון: ${median.toFixed(3)}</span>
+          </div>
+        </li>
+      `;
+    })
+    .join('');
+}
+
 function renderCity(primaryId, secondaryId = '') {
   const city = state.cityMap.get(primaryId);
   if (!city) {
@@ -2068,6 +2160,12 @@ function renderCity(primaryId, secondaryId = '') {
   setCityInputValue(elements.city.primarySelect, elements.city.primarySuggestions, primaryId);
 
   const similarity = state.similarityTop.get(primaryId) || [];
+  const uniqueCount = city.uniqueStreetCount ?? 0;
+  const uniqueShare = typeof city.uniqueStreetShare === 'number' ? city.uniqueStreetShare : city.streetCount ? uniqueCount / city.streetCount : 0;
+  const meanRarity = typeof city.meanRarityWeight === 'number' ? city.meanRarityWeight : 0;
+  const medianRarity = typeof city.medianRarityWeight === 'number' ? city.medianRarityWeight : 0;
+  const uniquenessRank = state.cityUniquenessRank.get(String(primaryId)) ?? city.uniquenessRank ?? null;
+  const rankLabel = uniquenessRank ? `#${uniquenessRank}` : '—';
   elements.city.summary.innerHTML = `
     <h2>${city.name}</h2>
     <div class="street-meta">
@@ -2078,6 +2176,18 @@ function renderCity(primaryId, secondaryId = '') {
       <div>
         <div>חיבורים משמעותיים:</div>
         <strong>${similarity.length}</strong>
+      </div>
+      <div>
+        <div>רחובות ייחודיים:</div>
+        <strong>${uniqueCount.toLocaleString()} (${formatPercentage(uniqueShare, 1)})</strong>
+      </div>
+      <div>
+        <div>מדד נדירות (ממוצע/חציון):</div>
+        <strong>${meanRarity.toFixed(3)} / ${medianRarity.toFixed(3)}</strong>
+      </div>
+      <div>
+        <div>דירוג ייחודיות ארצי:</div>
+        <strong>${rankLabel}</strong>
       </div>
     </div>
   `;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -233,6 +233,34 @@ a:hover {
   font-weight: 600;
 }
 
+.top-cities-list .row-main {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.top-cities-list .row-main .rank {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.1rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 255, 0.22);
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 0.75rem;
+}
+
+.top-cities-list .row-sub {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
 .chain-summary {
   display: grid;
   gap: 1rem;

--- a/src/aggregation/build_data.py
+++ b/src/aggregation/build_data.py
@@ -12,6 +12,7 @@ import logging
 import math
 import os
 import shutil
+import statistics
 import sys
 import time
 from collections import Counter, defaultdict
@@ -41,6 +42,8 @@ class StreetProcessingPipeline:
         self.city_names = {}
         self.city_communities = {}
         self.city_name_graph = {}
+        self.city_uniqueness = {}
+        self.city_uniqueness_ranking = []
 
     def load_data(self, csv_path):
         """Load street data from CSV file."""
@@ -104,6 +107,67 @@ class StreetProcessingPipeline:
 
         compute_time = time.time() - start_time
         logger.info("Computed rarity weights in %.2fs", compute_time)
+        return self
+
+    def compute_city_uniqueness_metrics(self):
+        """Summarize per-city uniqueness and rarity statistics."""
+        logger.info("Computing per-city uniqueness metrics")
+        start_time = time.time()
+
+        unique_counts = defaultdict(int)
+        for norm_key, cities in self.street_to_cities.items():
+            if len(cities) != 1:
+                continue
+            city_code = next(iter(cities))
+            unique_counts[city_code] += 1
+
+        metrics = {}
+        ranking_entries = []
+        for city_code, streets in self.cities_data.items():
+            street_keys = list(streets.keys())
+            total_streets = len(street_keys)
+            if total_streets:
+                weights = [self.rarity_weights.get(key, 0.0) for key in street_keys]
+                mean_weight = sum(weights) / total_streets if weights else 0.0
+                median_weight = statistics.median(weights) if weights else 0.0
+            else:
+                mean_weight = 0.0
+                median_weight = 0.0
+
+            unique_count = unique_counts.get(city_code, 0)
+            share = (unique_count / total_streets) if total_streets else 0.0
+
+            metrics[city_code] = {
+                'unique_street_count': unique_count,
+                'unique_street_share': share,
+                'mean_rarity_weight': mean_weight,
+                'median_rarity_weight': median_weight,
+            }
+
+            ranking_entries.append({
+                'id': str(city_code),
+                'name': self.city_names.get(city_code, ''),
+                'streetCount': total_streets,
+                'uniqueStreetCount': unique_count,
+                'uniqueStreetShare': share,
+                'meanRarityWeight': mean_weight,
+                'medianRarityWeight': median_weight,
+            })
+
+        ranking_entries.sort(
+            key=lambda item: (
+                -(item['uniqueStreetShare'] or 0.0),
+                -(item['uniqueStreetCount'] or 0),
+                -(item['meanRarityWeight'] or 0.0),
+                item['name'],
+            )
+        )
+
+        self.city_uniqueness = metrics
+        self.city_uniqueness_ranking = ranking_entries
+
+        elapsed = time.time() - start_time
+        logger.info("Computed uniqueness metrics for %d cities in %.2fs", len(metrics), elapsed)
         return self
 
     def calculate_jaccard_similarity(self, city_a_streets, city_b_streets):
@@ -577,6 +641,18 @@ class StreetProcessingPipeline:
             if community is not None:
                 city_entry['community'] = community
 
+            uniqueness = self.city_uniqueness.get(city_code)
+            if uniqueness:
+                city_entry['uniqueStreetCount'] = uniqueness['unique_street_count']
+                city_entry['uniqueStreetShare'] = round(uniqueness['unique_street_share'], 6)
+                city_entry['meanRarityWeight'] = round(uniqueness['mean_rarity_weight'], 6)
+                city_entry['medianRarityWeight'] = round(uniqueness['median_rarity_weight'], 6)
+            else:
+                city_entry['uniqueStreetCount'] = 0
+                city_entry['uniqueStreetShare'] = 0.0
+                city_entry['meanRarityWeight'] = 0.0
+                city_entry['medianRarityWeight'] = 0.0
+
             for key in sorted_keys:
                 info = city_meta.get(key, {})
                 city_entry['streets'].append({
@@ -593,6 +669,20 @@ class StreetProcessingPipeline:
 
         with open(os.path.join(output_dir, 'cities.json'), 'w', encoding='utf-8') as f:
             json.dump(cities_output, f, indent=2, ensure_ascii=False)
+
+        if self.city_uniqueness_ranking:
+            uniqueness_output = []
+            for rank, entry in enumerate(self.city_uniqueness_ranking, start=1):
+                uniqueness_output.append({
+                    **entry,
+                    'rank': rank,
+                    'uniqueStreetShare': round(entry['uniqueStreetShare'], 6),
+                    'meanRarityWeight': round(entry['meanRarityWeight'], 6),
+                    'medianRarityWeight': round(entry['medianRarityWeight'], 6),
+                })
+
+            with open(os.path.join(output_dir, 'city_uniqueness.json'), 'w', encoding='utf-8') as f:
+                json.dump(uniqueness_output, f, indent=2, ensure_ascii=False)
 
         # Build an index of streets to cities with metadata
         street_index_output = {}
@@ -653,6 +743,8 @@ class StreetProcessingPipeline:
             filenames.append('similarity_top.json')
         if self.city_name_graph:
             filenames.append('city_name_graph.json')
+        if self.city_uniqueness_ranking:
+            filenames.append('city_uniqueness.json')
 
         for filename in filenames:
             source = output_path / filename
@@ -678,6 +770,9 @@ def main():
 
     # Compute rarity weights
     pipeline.compute_rarity_weights()
+
+    # Summarize per-city uniqueness metrics
+    pipeline.compute_city_uniqueness_metrics()
 
     # Build city honor graph before similarity calculations
     pipeline.build_city_name_honor_graph()


### PR DESCRIPTION
## Summary
- compute per-city street uniqueness metrics and export both city-level fields and a ranking payload
- mirror the new aggregates into the frontend, surface them in the city summary, and render a “most distinctive cities” widget on the home view
- document the new metrics and outputs so downstream users understand the additional JSON files

## Testing
- python -m compileall src
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d261b520d0832ca24c9cc6c4cd0d68