### PR TITLE
Add Google Analytics snippet to index page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <title>מפת הדמיון בין רחובות בישראל</title>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-L41D4QFEFT"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+
+      gtag('config', 'G-L41D4QFEFT');
+    </script>
   </head>
   <body>
     <div id="app" class="app-shell">


### PR DESCRIPTION
## Summary
- embed the Google Analytics 4 gtag snippet into the frontend HTML head to enable tracking

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea87769d0832c85e6a0ff9ef7c430