### PR TITLE
Add community street legend to graph view

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -161,6 +161,9 @@
                 </div>
               </div>
               <div id="graph-view-canvas" class="viz-canvas network full"></div>
+              <div id="graph-community-legend" class="graph-community-legend">
+                <p class="legend-note">טוען רשימת רחובות ייחודיים לקהילות…</p>
+              </div>
             </section>
           </section>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -56,6 +56,7 @@ const state = {
     total: 0
   },
   graphNodeScoreCache: new Map(),
+  communityStreetSignatures: new Map(),
   cityView: {
     autoDefaultUsed: false,
     primaryId: '',
@@ -91,6 +92,8 @@ const HEBREW_COLLATOR = new Intl.Collator('he', {
   numeric: true
 });
 
+const NUMBER_FORMAT = new Intl.NumberFormat('he-IL');
+
 const STREET_DIRECTORY_BATCH_SIZE = 150;
 
 const elements = {
@@ -109,7 +112,8 @@ const elements = {
     metricSelect: document.getElementById('graph-metric-select'),
     focusInput: document.getElementById('graph-focus-city'),
     focusSuggestions: document.getElementById('graph-focus-suggestions'),
-    focusClear: document.getElementById('graph-focus-clear')
+    focusClear: document.getElementById('graph-focus-clear'),
+    communityLegend: document.getElementById('graph-community-legend')
   },
   dedications: {
     summary: document.getElementById('city-chain-summary'),
@@ -142,6 +146,25 @@ let resizeTimer = null;
 
 function makeEdgeKey(source, target) {
   return `${source}__${target}`;
+}
+
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, char => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return char;
+    }
+  });
 }
 
 function toggleLoading(show, message = 'טוען נתונים...') {
@@ -767,6 +790,7 @@ async function loadData() {
         });
       }
     });
+    updateCommunityStreetSignatures();
     state.rarityWeights = rarity || {};
     state.cityHonors = prepareCityHonorGraph(honorGraph);
     state.cityFuse = state.cities.length
@@ -1258,6 +1282,108 @@ function updateGraphCommunityStats() {
   };
 }
 
+function updateCommunityStreetSignatures() {
+  const summaryMap = new Map();
+  if (!state.streetIndex || state.streetIndex.size === 0) {
+    state.communityStreetSignatures = summaryMap;
+    return;
+  }
+
+  const cityCommunity = new Map();
+  state.cities.forEach(city => {
+    if (!city) return;
+    const id = String(city.id || '');
+    if (!id) return;
+    const community = typeof city.community === 'number' && Number.isFinite(city.community)
+      ? city.community
+      : null;
+    if (community === null) return;
+    cityCommunity.set(id, community);
+  });
+
+  if (cityCommunity.size === 0) {
+    state.communityStreetSignatures = summaryMap;
+    return;
+  }
+
+  const accumulator = new Map();
+
+  state.streetIndex.forEach((entry, streetKey) => {
+    if (!entry) return;
+    const cityEntries = Array.isArray(entry.cities) ? entry.cities : [];
+    if (!cityEntries.length) return;
+
+    let communityId = null;
+    let valid = true;
+    let cityCount = 0;
+    const seenCities = new Set();
+
+    for (const cityEntry of cityEntries) {
+      if (!cityEntry) continue;
+      const cityId = String(cityEntry.id ?? cityEntry.city ?? '');
+      if (!cityId || seenCities.has(cityId)) continue;
+      seenCities.add(cityId);
+      if (!cityCommunity.has(cityId)) {
+        valid = false;
+        break;
+      }
+      const assigned = cityCommunity.get(cityId);
+      if (communityId === null) {
+        communityId = assigned;
+      } else if (communityId !== assigned) {
+        valid = false;
+        break;
+      }
+      cityCount += 1;
+    }
+
+    if (!valid || communityId === null || cityCount === 0) {
+      return;
+    }
+
+    const normalizedCommunity = Number(communityId);
+    if (!Number.isFinite(normalizedCommunity)) {
+      return;
+    }
+
+    if (!accumulator.has(normalizedCommunity)) {
+      accumulator.set(normalizedCommunity, []);
+    }
+
+    const display = typeof entry.display === 'string' && entry.display.trim()
+      ? entry.display.trim()
+      : streetKey;
+
+    accumulator.get(normalizedCommunity).push({
+      key: streetKey,
+      display,
+      cityCount,
+      rarityWeight: Number(entry.rarityWeight || 0)
+    });
+  });
+
+  accumulator.forEach((streets, communityId) => {
+    if (!streets || streets.length === 0) return;
+    const sorted = streets
+      .slice()
+      .sort((a, b) => {
+        const countDiff = (b.cityCount || 0) - (a.cityCount || 0);
+        if (countDiff !== 0) return countDiff;
+        const rarityDiff = (b.rarityWeight || 0) - (a.rarityWeight || 0);
+        if (Math.abs(rarityDiff) > 1e-6) return rarityDiff;
+        return HEBREW_COLLATOR.compare(a.display || '', b.display || '');
+      });
+    const trimmed = sorted.slice(0, 60);
+    summaryMap.set(communityId, {
+      communityId,
+      total: sorted.length,
+      streets: trimmed
+    });
+  });
+
+  state.communityStreetSignatures = summaryMap;
+}
+
 function computeGraphFocusNeighborhood(cityId, depth = 2) {
   const normalized = String(cityId || '');
   if (!normalized || !state.cityMap.has(normalized)) {
@@ -1662,6 +1788,7 @@ function renderNetworkGraph(target, options = {}) {
       ? 'לא נמצאו ערים במרחק של עד שתי קפיצות מהעיר שנבחרה.'
       : 'לא נמצאו ערים להצגה.';
     container.innerHTML = `<p class="empty-state">${message}</p>`;
+    renderGraphCommunityLegend({ nodes: [], communityScale: null });
     return;
   }
 
@@ -2056,6 +2183,8 @@ function renderNetworkGraph(target, options = {}) {
   simulation.on('tick', updatePositions);
   simulation.on('end', snapshotLayout);
 
+  renderGraphCommunityLegend({ nodes, communityScale });
+
   console.info('[viz] renderNetworkGraph end', {
     nodes: nodes.length,
     links: trimmedLinks.length,
@@ -2064,6 +2193,110 @@ function renderNetworkGraph(target, options = {}) {
     metric: metricKey,
     focusCityId: focusId || null
   });
+}
+
+function renderGraphCommunityLegend({ nodes = [], communityScale } = {}) {
+  const container = elements.graph.communityLegend;
+  if (!container) return;
+
+  const headerHtml = '<h3>רחובות מזהים לפי קהילה</h3>';
+  const noteHtml =
+    '<p class="legend-note">הרחובות ברשימה מופיעים רק בערים מתוך אותה קהילה ומייצגים חתימה ייחודית שלה.</p>';
+
+  const communities = Array.isArray(nodes)
+    ? Array.from(
+        new Set(
+          nodes
+            .map(node =>
+              typeof node.community === 'number' && Number.isFinite(node.community) ? node.community : null
+            )
+            .filter(value => value !== null)
+        )
+      ).sort((a, b) => a - b)
+    : [];
+
+  if (!communityScale || typeof communityScale !== 'function' || communities.length === 0) {
+    container.innerHTML =
+      headerHtml +
+      noteHtml +
+      '<p class="legend-community-empty">לא נמצאו קהילות עם צבעים מזוהים לגרף הנוכחי.</p>';
+    container.hidden = false;
+    return;
+  }
+
+  const statsMap = state.graphCommunities && state.graphCommunities.map instanceof Map
+    ? state.graphCommunities.map
+    : null;
+
+  const blocks = communities
+    .map(communityId => {
+      const signature = state.communityStreetSignatures.get(communityId) || { streets: [], total: 0 };
+      const topStreets = Array.isArray(signature.streets) ? signature.streets.slice(0, 20) : [];
+      const totalUnique = typeof signature.total === 'number' ? signature.total : topStreets.length;
+      const statsKey = `c${communityId}`;
+      const statsEntry = statsMap ? statsMap.get(statsKey) : null;
+      const totalCities = statsEntry && typeof statsEntry.size === 'number'
+        ? statsEntry.size
+        : nodes.filter(node => node.community === communityId).length;
+      const metaParts = [];
+      if (totalCities > 0) {
+        metaParts.push(`${NUMBER_FORMAT.format(totalCities)} ערים`);
+      }
+      if (totalUnique > 0) {
+        const uniqueLabel = totalUnique > 20
+          ? `מתוך ${NUMBER_FORMAT.format(totalUnique)} רחובות ייחודיים`
+          : `${NUMBER_FORMAT.format(totalUnique)} רחובות ייחודיים`;
+        metaParts.push(uniqueLabel);
+      } else {
+        metaParts.push('אין רחובות ייחודיים');
+      }
+      const metaHtml = metaParts.length
+        ? `<span class="legend-community-meta">${metaParts.join(' · ')}</span>`
+        : '';
+
+      const listHtml = topStreets.length
+        ? `<ol class="legend-street-list">${topStreets
+            .map(street => {
+              const name = escapeHtml(street.display || street.key || '');
+              const countLabel = street.cityCount > 1
+                ? `${NUMBER_FORMAT.format(street.cityCount)} ערים`
+                : 'עיר אחת';
+              return `<li><span class="legend-street-name">${name}</span><span class="legend-street-count">${countLabel}</span></li>`;
+            })
+            .join('')}</ol>`
+        : '<p class="legend-community-empty">לא נמצאו רחובות ייחודיים לקהילה זו.</p>';
+
+      const color = communityScale(communityId);
+      const colorStyle = typeof color === 'string' && color.trim() ? color : '#6b7280';
+      const indexLabel = NUMBER_FORMAT.format(communityId + 1);
+
+      return `
+        <section class="legend-community">
+          <div class="legend-community-header">
+            <span class="legend-community-title">
+              <span class="legend-community-dot" style="background:${colorStyle}"></span>
+              קהילה ${indexLabel}
+            </span>
+            ${metaHtml}
+          </div>
+          ${listHtml}
+        </section>
+      `;
+    })
+    .join('');
+
+  const trimmedBlocks = blocks.trim();
+  if (!trimmedBlocks) {
+    container.innerHTML =
+      headerHtml +
+      noteHtml +
+      '<p class="legend-community-empty">לא נמצאו רחובות ייחודיים לקהילות המוצגות.</p>';
+    container.hidden = false;
+    return;
+  }
+
+  container.innerHTML = `${headerHtml}${noteHtml}<div class="graph-community-legend-grid">${trimmedBlocks}</div>`;
+  container.hidden = false;
 }
 function renderNetworkPreview(force = false) {
   const container = elements.home.network;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -229,6 +229,102 @@ a:hover {
   box-shadow: 0 8px 18px rgba(203, 138, 79, 0.25);
 }
 
+.graph-community-legend {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(210, 180, 149, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.graph-community-legend h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.graph-community-legend .legend-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.graph-community-legend-grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.legend-community {
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(218, 188, 150, 0.45);
+  border-radius: 16px;
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  box-shadow: 0 14px 30px rgba(196, 156, 110, 0.16);
+}
+
+.legend-community-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.legend-community-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 700;
+}
+
+.legend-community-dot {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  flex-shrink: 0;
+}
+
+.legend-community-meta {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.legend-street-list {
+  margin: 0;
+  padding: 0 1rem 0 0;
+  list-style: decimal inside;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.92rem;
+}
+
+.legend-street-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  line-height: 1.35;
+}
+
+.legend-street-name {
+  font-weight: 500;
+}
+
+.legend-street-count {
+  color: var(--muted);
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.legend-community-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
 .viz-canvas.bars {
   min-height: 360px;
 }


### PR DESCRIPTION
## Summary
- add a community legend container to the graph view so the visualization has room for descriptive context
- compute per-community street signatures from the street index during data load and reuse them across renders
- render a color-coded legend that lists up to twenty unique streets per community and style the layout to match the graph palette

## Testing
- npm --prefix frontend run lint *(fails: missing ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e8dd751fe4832ca6a3a827acbd7e58